### PR TITLE
Fix compilation with rust nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ cargo test
 
 #![feature(collections)]
 #![feature(convert)]
+#![feature(bitvec)]
 
 // extern crate bst;
 extern crate url;


### PR DESCRIPTION
Seems the bitvec feature has been moved behind a flag