### PR TITLE
Remove leading / from the vhost

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -62,12 +62,19 @@ impl Session {
             let input = string.as_bytes();
             percent_encoding::lossy_utf8_percent_decode(input)
         }
+        fn clean_vhost(string: String) -> String {
+            if &string.chars().next() == &Some('/') {
+              String::from(decode(&string[1..]))
+            } else {
+              String::from(decode(&string[..]))
+            }
+        }
 
         let default: Options = Default::default();
         let mut url_parser = UrlParser::new();
         url_parser.scheme_type_mapper(scheme_type_mapper);
         let url = try!(url_parser.parse(url_string));
-        let vhost = url.serialize_path().unwrap_or(default.vhost.to_string());
+        let vhost = url.serialize_path().map(|vh| clean_vhost(vh)).unwrap_or(String::from(default.vhost.to_string()));
         let host  = url.domain().unwrap_or(default.host);
         let port = url.port().unwrap_or(default.port);
         let login = url.username().and_then(|u| match u { "" => None, _ => Some(decode(u))} ).unwrap_or(String::from(default.login));


### PR DESCRIPTION
Fixes #8

As per the AMQP uri spec <https://www.rabbitmq.com/uri-spec.html>

    The vhost component of the URI does not include the leading "/"
    character from the path.

and

    Any percent-encoded octets in the vhost should be decoded before
    it is passed to the server.