### PR TITLE
Misc and minor fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@
 name = "amqp"
 version = "0.0.9"
 authors = ["Andrii Dmytrenko <andrey@reevoo.com>"]
-description = "AMQP/RabbitMQ protocol client."
+description = "AMQP/RabbitMQ protocol client"
+repository = "https://github.com/Antti/rust-amqp"
 license = "MIT/BSD-2-Clause"
 keywords = ["amqp", "rabbitmq", "queue"]
 readme = "Readme.md"

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,5 @@ all: src/protocol.rs
 
 src/protocol.rs: codegen.rb codegen.erb amqp-rabbitmq-0.9.1.json
 	ruby codegen.rb > src/protocol.rs
+
+.PHONY: src/protocol.rs all

--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ AMQ protocol implementation in pure rust.
 * Declare queues/exchanges
 * All the methods from the Basic class are implemented, including get, publish, ack, nack, reject, consume. So you can send/receive messages.
 
-Have a look at the examples in examples folder.
+Have a look at the examples in `examples/` folder.
 
 
 ### Connecting to the server & openning channel:
@@ -55,13 +55,16 @@ To generate a new spec, run:
 make
 ```
 
-To build project, use cargo:
+To build the project and run the testsuite, use cargo:
 
 ```sh
 cargo build
+cargo test
 ```
 
-To build examples:
+Moreover, there are several source examples to show library usage, and an interactive one to quickly test the library.
+They can be run directly from cargo:
+
 ```sh
-cargo test
+cargo run --example interactive
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ channel.basic_publish("", "my_queue_name", true, false,
 
 This will send message: "Hello from rust!" to the queue named "my_queue_name".
 
-The messages have type of Vec<u8>, so if you want to send string, first you must convert it to Vec<u8>.
+The messages have type of `Vec<u8>`, so if you want to send string, first you must convert it to `Vec<u8>`.
 
 ## Development notes:
 

--- a/codegen.rb
+++ b/codegen.rb
@@ -22,14 +22,14 @@ def read_type(type)
     "{
           let size = try!(reader.read_u8()) as usize;
           let mut buffer: Vec<u8> = iter::repeat(0u8).take(size).collect();
-          try!(reader.read(buffer.as_mut_slice()));
+          try!(reader.read(&mut buffer[..]));
           String::from_utf8_lossy(&buffer[..]).to_string()
      }"
   when "longstr"
     "{
           let size = try!(reader.read_u32::<BigEndian>()) as usize;
           let mut buffer: Vec<u8> = iter::repeat(0u8).take(size).collect();
-          try!(reader.read(buffer.as_mut_slice()));
+          try!(reader.read(&mut buffer[..]));
           String::from_utf8_lossy(&buffer[..]).to_string()
       }"
   when "table"

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -1,0 +1,42 @@
+extern crate amqp;
+extern crate env_logger;
+
+use amqp::session::Session;
+use amqp::protocol;
+use amqp::table;
+use amqp::basic::Basic;
+use std::default::Default;
+use std::io;
+
+fn main() {
+    env_logger::init().unwrap();
+    let mut amqp_url = String::new();
+    println!("Please input the AMQP endpoint to use: ");
+    io::stdin().read_line(&mut amqp_url).ok().expect("Unable to read URL!");
+    let mut session = match Session::open_url(&amqp_url[..]) {
+        Ok(session) => session,
+        Err(error) => panic!("Can't create session: {:?}", error)
+    };
+    let mut channel = session.open_channel(1).ok().expect("Can't open channel!");
+
+    let queue_name = "test_queue";
+    channel.queue_declare(queue_name, false, true, false, false, false, table::new()).ok().expect("Unable to declare queue!");
+
+    println!("Type some text here below, it will be sent into the '{}' queue. Hit Enter when done.", queue_name);
+    let mut input_data = String::new();
+    io::stdin().read_line(&mut input_data).ok().expect("Unable to read input data!");
+
+    println!("Sending data...\n");
+    channel.basic_publish("", queue_name, true, false,
+        protocol::basic::BasicProperties{ content_type: Some("text".to_string()), ..Default::default()},
+        input_data.trim_right().to_string().into_bytes());
+
+     for get_result in channel.basic_get(queue_name, false) {
+        println!("Received: {:?}", String::from_utf8_lossy(&get_result.body));
+        get_result.ack();
+    }
+
+    println!("Queue is now empty, quitting...");
+    channel.close(200, "Bye".to_string());
+    session.close(200, "Good Bye".to_string());
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -15,6 +15,9 @@ use std::cmp;
 
 use url::{UrlParser, SchemeType, percent_encoding};
 
+pub const AMQPS_PORT: u16 = 5671;
+pub const AMQP_PORT:  u16 = 5672;
+
 const CHANNEL_BUFFER_SIZE : usize = 100;
 
 
@@ -33,7 +36,7 @@ pub struct Options <'a>  {
 impl <'a>  Default for Options <'a>  {
     fn default() -> Options <'a>  {
         Options {
-            host: "127.0.0.1", port: 5672, vhost: "",
+            host: "127.0.0.1", port: AMQP_PORT, vhost: "",
             login: "guest", password: "guest",
             frame_max_limit: 131072, channel_max_limit: 65535,
             locale: "en_US"
@@ -247,7 +250,7 @@ fn negotiate<T : cmp::Ord>(their_value: T, our_value: T) -> T {
 }
 fn scheme_type_mapper(scheme: &str) -> SchemeType {
     match scheme{
-        "amqp" => SchemeType::Relative(5672),
+        "amqp" => SchemeType::Relative(AMQP_PORT),
         _ => {panic!("Uknown scheme: {}", scheme)}
     }
 }


### PR DESCRIPTION
This is a pile of really small/cosmetic fixes I collected in the last few days. A brief summary of changes:
 * constify port numbers as per IANA registry
 * synchronize codegen as per my latest PR, to avoid emitting code using unstable features
 * add an interactive example; I use this a lot to quickly try stuff, so it may be useful having it here
 * update Readme and Cargo manifest with some more details
 * tweak Makefile to always execute targets