### PR TITLE
amqp: add optional TLS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ readme = "Readme.md"
 
 name = "amqp"
 
+[features]
+tls = ["openssl"]
+default = ["tls"]
+
 [dependencies]
 log = "*"
 env_logger = "*"
@@ -21,3 +25,8 @@ byteorder = "*"
 url = "*"
 enum_primitive = "*"
 bit-vec ="*"
+
+[dependencies.openssl]
+version = "0.6"
+optional = true
+features = ["tlsv1_1", "tlsv1_2"]

--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,6 @@ Have a look at the examples in `examples/` folder.
 
 
 ### Connecting to the server & openning channel:
->Note: Currently it can't connect using TLS connections.
 
 ```rust
 extern crate amqp;
@@ -27,6 +26,9 @@ use amqp::table;
 let mut session = Session::open_url("amqp://localhost/").unwrap();
 let mut channel = session.open_channel(1).unwrap();
 ```
+
+> Note: This library supports TLS connections, via OpenSSL.
+> However, this is an optional feature that is enabled by default but can be disabled at build-time (via `cargo --no-default-features` on the command-line, or with `default-features = false` in your `Cargo.toml`).
 
 ### Declaring queue:
 ```rust

--- a/src/amqp_error.rs
+++ b/src/amqp_error.rs
@@ -3,6 +3,11 @@ use std::io;
 use byteorder;
 use url;
 
+#[cfg(feature = "tls")]
+use openssl;
+#[cfg(feature = "tls")]
+use std::error::Error;
+
 #[derive(Debug, Clone)]
 pub enum AMQPError {
     AMQPIoError(io::ErrorKind),
@@ -32,5 +37,12 @@ impl From<byteorder::Error> for AMQPError {
 impl From<url::ParseError> for AMQPError {
     fn from(err: url::ParseError) -> AMQPError {
         AMQPError::UrlParseError(err)
+    }
+}
+
+#[cfg(feature = "tls")]
+impl From<openssl::ssl::error::SslError> for AMQPError {
+    fn from(err: openssl::ssl::error::SslError) -> AMQPError {
+        AMQPError::Protocol(format!("{}", err))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,10 @@ cargo test
 extern crate url;
 extern crate byteorder;
 extern crate bit_vec;
+
+#[cfg(feature = "tls")]
+extern crate openssl;
+
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
This commit adds optional TLS support, using OpenSSL.
It is enabled by default and pull in an additional dependency on
the openssl crate.
However, if not needed this can be disabled with `cargo --no-default-features`.
It has been successfully tested against a third-party RabbitMQ (3.5.3) instance.

***

As I was not sure if the lack of TLS support, explicitly mentioned in the README, was a design decision, I implemented this part as an optional feature/dependency, enabled by default. This may also allow you to swap in a different TLS library later. Let me know if this is ok for you, or if you prefer to directly wire it.
