### PR TITLE
Upgrade openssl to 0.7.*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ url = "0.2"
 clippy = {version = "0.0.41", optional = true}
 
 [dependencies.openssl]
-version = "0.6"
+version = "0.7.*"
 optional = true
 features = ["tlsv1_1", "tlsv1_2"]


### PR DESCRIPTION
Seems like a simple cargo.toml update is enough to fix all the issues I was having.

I tested the change on Arch Linux and CentOS 7.