### PR TITLE
include vhost in readme connect example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,7 @@ Have a look at the examples in `examples/` folder.
 extern crate amqp;
 use amqp::Session;
 
-let mut session = Session::open_url("amqp://localhost/").unwrap();
+let mut session = Session::open_url("amqp://localhost//").unwrap();
 let mut channel = session.open_channel(1).unwrap();
 ```
 


### PR DESCRIPTION
Without the extra `/` in the example it tries to connect without a vhost which causes mysterious `ConnectionReset` errors or `Protocol("Unexpected method frame: connection.close, expected: connection.open-ok")` depending on configuration and OS. 