### PR TITLE
 impl Consumer for unboxed closure and Box<Consumer>

### DIFF
--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -1,7 +1,7 @@
 extern crate amqp;
 extern crate env_logger;
 
-use amqp::{Session, Options, Table, Basic, protocol, Channel, ConsumerCallBackFn};
+use amqp::{Session, Options, Table, Basic, protocol, Channel};
 use amqp::protocol::basic;
 use std::default::Default;
 
@@ -46,7 +46,7 @@ fn main() {
     //consumer, queue: &str, consumer_tag: &str, no_local: bool, no_ack: bool, exclusive: bool, nowait: bool, arguments: Table
     println!("Declaring consumers...");
 
-    let consumer_name = channel.basic_consume(consumer_function  as ConsumerCallBackFn, queue_name, "", false, false, false, false, Table::new());
+    let consumer_name = channel.basic_consume(consumer_function, queue_name, "", false, false, false, false, Table::new());
     println!("Starting consumer {:?}", consumer_name);
 
     let my_consumer = MyConsumer { deliveries_number: 0 };
@@ -54,14 +54,13 @@ fn main() {
     println!("Starting consumer {:?}", consumer_name);
 
     let mut delivery_log = vec![];
-    let closure_consumer = Box::new(move |_chan: &mut Channel, deliver: basic::Deliver, headers: basic::BasicProperties, data: Vec<u8>|
-        {
-            println!("[closure] Deliver info: {:?}", deliver);
-            println!("[closure] Content headers: {:?}", headers);
-            println!("[closure] Content body: {:?}", data);
-            delivery_log.push(deliver);
-        }
-    );
+    let closure_consumer = move |_chan: &mut Channel, deliver: basic::Deliver, headers: basic::BasicProperties, data: Vec<u8>|
+    {
+        println!("[closure] Deliver info: {:?}", deliver);
+        println!("[closure] Content headers: {:?}", headers);
+        println!("[closure] Content body: {:?}", data);
+        delivery_log.push(deliver);
+    };
     let consumer_name = channel.basic_consume(closure_consumer, queue_name, "", false, false, false, false, Table::new());
     println!("Starting consumer {:?}", consumer_name);
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,7 @@
 extern crate amqp;
 extern crate env_logger;
 
-use amqp::{Basic, Session, Channel, ConsumerCallBackFn, Table, protocol};
+use amqp::{Basic, Session, Channel, Table, protocol};
 use std::default::Default;
 use std::thread;
 
@@ -39,7 +39,7 @@ fn main() {
 
     //queue: &str, consumer_tag: &str, no_local: bool, no_ack: bool, exclusive: bool, nowait: bool, arguments: Table
     println!("Declaring consumer...");
-    let consumer_name = channel.basic_consume(consumer_function as ConsumerCallBackFn, queue_name, "", false, false, false, false, Table::new());
+    let consumer_name = channel.basic_consume(consumer_function, queue_name, "", false, false, false, false, Table::new());
     println!("Starting consumer {:?}", consumer_name);
 
     let consumers_thread = thread::spawn(move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ mod amqp_error;
 pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 pub use session::{Session, Options};
-pub use channel::{Channel, ConsumerCallBackFn, Consumer};
+pub use channel::{Channel, Consumer};
 pub use basic::{Basic, GetResult};
 pub use session::AMQPScheme;
 pub use amqp_error::AMQPError;


### PR DESCRIPTION
Hey, I wanted to be able to loop over a list of consumers and add them to a basic_consume, this pull request allows that. There were a few breaking changes but (to me) they seem to allow more flexibility.

Breaking change: Removal of ```ConsumerCallBackFn```  The ```impl Consumer for ConsumerCallBackFn``` is covered by the changed ```impl<F> Consumer for F where F: FnMut(...)```
Breaking change: Removal of the box wrapper around the existing FnMut impl for Consumer. This was required for the blanket impl of all boxed consumers, removing the box has also allowed passing in of the closure directly, which is nice for usability.
Possible Breaking Change: I've had to add the 'static lifetime to the ```impl<F> Consumer for F where F: FnMut(...)```. I'm not confident enough to say this will not break something, but since ```basic_consume``` requires ```Consumer + 'static``` I guess that this would be safe.