### PR TITLE
Upgrade to OpenSSL 0.9.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ env_logger = "0.3"
 log = "0.3"
 url = "1.2"
 amq-proto = "0.1.0"
+time = "0.1.38"
 
 [dependencies.openssl]
 version = "0.9.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ url = "1.2"
 amq-proto = "0.1.0"
 
 [dependencies.openssl]
-version = "0.7.*"
+version = "0.9.*"
 optional = true
-features = ["tlsv1_1", "tlsv1_2"]
+# features = ["tlsv1_1", "tlsv1_2"]
 
 [dev-dependencies]
 # clippy  = "*"

--- a/src/amqp_error.rs
+++ b/src/amqp_error.rs
@@ -68,8 +68,17 @@ impl From<amq_proto::Error> for AMQPError {
 }
 
 #[cfg(feature = "tls")]
-impl From<openssl::ssl::error::SslError> for AMQPError {
-    fn from(err: openssl::ssl::error::SslError) -> AMQPError {
+impl From<openssl::ssl::Error> for AMQPError {
+    fn from(err: openssl::ssl::Error) -> AMQPError {
+        AMQPError::Protocol(format!("{}", err))
+    }
+}
+
+#[cfg(feature = "tls")]
+impl <S: 'static> From<openssl::ssl::HandshakeError<S>> for AMQPError
+    where S: fmt::Debug {
+
+    fn from(err: openssl::ssl::HandshakeError<S>) -> AMQPError {
         AMQPError::Protocol(format!("{}", err))
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -89,7 +89,7 @@ impl Channel {
             let frame = try!(self.receiver
                 .recv()
                 .map_err(|_| AMQPError::Protocol("Error reading packet from channel".to_owned()))
-                             .and_then(|frame| frame));
+                .and_then(|frame| frame));
             trace!("Got a frame: {:?}", frame);
             unprocessed_frame = try!(self.try_consume(frame));
         }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -354,6 +354,14 @@ impl<'a> Basic<'a> for Channel {
                         -> AMQPResult<()>
         where S: Into<String>
     {
+        if mandatory {
+            warn!("basic_publish(mandatory=true) failures are not handled and result in blocked channels!");
+        }
+
+        if immediate {
+            warn!("basic_publish(immediate=true) failures are not handled and result in blocked channels!");
+        }
+
         let publish = &Publish {
             ticket: 0,
             exchange: exchange.into(),

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -94,18 +94,6 @@ impl Connection {
         }
     }
 
-    pub fn take_error(&mut self) -> Result<Option<io::Error>, io::Error> {
-        match self.socket {
-            AMQPStream::Cleartext(ref mut stream) => {
-                stream.take_error()
-            },
-            #[cfg(feature = "tls")]
-            AMQPStream::Tls(ref mut stream) => {
-                stream.get_ref().take_error()
-            }
-        }
-    }
-
     fn write_frame(&mut self, frame: Frame) -> AMQPResult<()> {
         match self.socket {
             AMQPStream::Cleartext(ref mut stream) => {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -24,7 +24,7 @@ impl Connection {
     #[cfg(feature = "tls")]
     pub fn open_tls(host: &str, port: u16) -> AMQPResult<Connection> {
         let socket = try!(TcpStream::connect((host, port)));
-        socket.set_read_timeout(Some(time::Duration::from_millis(100)));
+        socket.set_read_timeout(Some(time::Duration::from_millis(150)));
         let connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap().build();
 
         let mut tls_socket = try!(connector.connect(host, socket));

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -24,7 +24,7 @@ impl Connection {
     #[cfg(feature = "tls")]
     pub fn open_tls(host: &str, port: u16) -> AMQPResult<Connection> {
         let socket = try!(TcpStream::connect((host, port)));
-        socket.set_read_timeout(Some(time::Duration::from_millis(50)));
+        socket.set_read_timeout(Some(time::Duration::from_millis(75)));
         let connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap().build();
 
         let mut tls_socket = try!(connector.connect(host, socket));

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -24,7 +24,7 @@ impl Connection {
     #[cfg(feature = "tls")]
     pub fn open_tls(host: &str, port: u16) -> AMQPResult<Connection> {
         let socket = try!(TcpStream::connect((host, port)));
-        socket.set_read_timeout(Some(time::Duration::from_millis(75)));
+        socket.set_read_timeout(Some(time::Duration::from_millis(100)));
         let connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap().build();
 
         let mut tls_socket = try!(connector.connect(host, socket));

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -24,7 +24,7 @@ impl Connection {
     #[cfg(feature = "tls")]
     pub fn open_tls(host: &str, port: u16) -> AMQPResult<Connection> {
         let socket = try!(TcpStream::connect((host, port)));
-        socket.set_read_timeout(Some(time::Duration::from_secs(1)));
+        socket.set_read_timeout(Some(time::Duration::from_millis(250)));
         let connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap().build();
 
         let mut tls_socket = try!(connector.connect(host, socket));

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -24,7 +24,7 @@ impl Connection {
     #[cfg(feature = "tls")]
     pub fn open_tls(host: &str, port: u16) -> AMQPResult<Connection> {
         let socket = try!(TcpStream::connect((host, port)));
-        socket.set_read_timeout(Some(time::Duration::from_millis(100)));
+        socket.set_read_timeout(Some(time::Duration::from_millis(50)));
         let connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap().build();
 
         let mut tls_socket = try!(connector.connect(host, socket));

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,5 +1,6 @@
 use std::net::TcpStream;
 use std::io::Write;
+use std::io;
 use std::cmp;
 use std::time;
 
@@ -76,6 +77,18 @@ impl Connection {
             #[cfg(feature = "tls")]
             AMQPStream::Tls(ref mut stream) => {
                 Frame::decode(stream).map_err(From::from)
+            }
+        }
+    }
+
+    pub fn take_error(&mut self) -> Result<Option<io::Error>, io::Error> {
+        match self.socket {
+            AMQPStream::Cleartext(ref mut stream) => {
+                stream.take_error()
+            },
+            #[cfg(feature = "tls")]
+            AMQPStream::Tls(ref mut stream) => {
+                stream.get_ref().take_error()
             }
         }
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -25,7 +25,7 @@ impl Connection {
     #[cfg(feature = "tls")]
     pub fn open_tls(host: &str, port: u16) -> AMQPResult<Connection> {
         let socket = try!(TcpStream::connect((host, port)));
-        socket.set_read_timeout(Some(time::Duration::from_millis(150)));
+        socket.set_read_timeout(Some(time::Duration::from_millis(250)));
         let connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap().build();
 
         let mut tls_socket = try!(connector.connect(host, socket));

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -24,7 +24,7 @@ impl Connection {
     #[cfg(feature = "tls")]
     pub fn open_tls(host: &str, port: u16) -> AMQPResult<Connection> {
         let socket = try!(TcpStream::connect((host, port)));
-        socket.set_read_timeout(Some(time::Duration::from_millis(250)));
+        socket.set_read_timeout(Some(time::Duration::from_millis(100)));
         let connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap().build();
 
         let mut tls_socket = try!(connector.connect(host, socket));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate url;
+extern crate time;
 
 #[cfg(feature = "tls")]
 extern crate openssl;

--- a/src/session.rs
+++ b/src/session.rs
@@ -13,7 +13,7 @@ use std::io::ErrorKind;
 use std::sync::{Arc, Mutex};
 use std::default::Default;
 use std::collections::HashMap;
-use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
+use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
 
 use std::thread;
 use std::cmp;
@@ -303,15 +303,35 @@ impl Session {
                     }
 
                     let target = chans.get(&chan_id);
-                    let dispatch = match target {
+
+                    match target {
                         Some(target_channel) => {
-                            target_channel.send(Ok(frame)).map_err(|_| {
-                                format!("Error dispatching packet to channel {}", chan_id)
-                            })
-                        }
-                        None => Err(format!("Received frame for an unknown channel: {}", chan_id)),
-                    };
-                    dispatch.map_err(|e| error!("{}", e)).ok();
+                            match target_channel.try_send(Ok(frame)) {
+                                Ok(()) => {},
+                                Err(TrySendError::Disconnected(frame)) => {
+                                    warn!(
+                                        "Error dispatching packet to channel {}: Receiver is gone.",
+                                        &chan_id
+                                    );
+                                },
+                                Err(TrySendError::Full(frame)) => {
+                                    warn!(
+                                        "Error dispatching packet to channel {}: Full! Blocking until there is space.",
+                                        &chan_id
+                                    );
+
+                                    if let Err(err) = target_channel.send(frame) {
+                                        warn!(
+                                            "Error dispatching packet to channel {}, Even after waiting for a blocked write: {:?}",
+                                            &chan_id,
+                                            err
+                                        );
+                                    }
+                                }
+                            }
+                        },
+                        None => error!("Received frame for an unknown channel: {}", chan_id),
+                    }
                 }
                 Err(read_err) => {
                     trace!("Error in reading loop: {:?}", read_err);

--- a/src/session.rs
+++ b/src/session.rs
@@ -270,7 +270,7 @@ impl Session {
                     match frame {
                         EventFrame::Frame(frame) => {
                             trace!("Writing frame: {:?}", frame);
-                            connection.write(frame);
+                            connection.write(frame).expect("failed to write frame");
                         }
                         EventFrame::FrameMaxLimit(limit) => {
                             trace!("Max frame limit: {:?}", limit);
@@ -294,6 +294,11 @@ impl Session {
                     // then reply code 503 (command invalid).
                     let chans = channels.lock().unwrap();
                     let chan_id = frame.channel;
+
+                    if chan_id == 0 {
+                        info!("Dropping mesesage to channel 0: {:?}", frame);
+                    }
+
                     let target = chans.get(&chan_id);
                     let dispatch = match target {
                         Some(target_channel) => {

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,8 +10,10 @@ use super::VERSION;
 use std::sync::{Arc, Mutex};
 use std::default::Default;
 use std::collections::HashMap;
-use std::sync::mpsc::{SyncSender, sync_channel};
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
+
 use std::thread;
+use std::time;
 use std::cmp;
 
 
@@ -27,6 +29,11 @@ pub enum AMQPScheme {
     AMQP,
     #[cfg(feature = "tls")]
     AMQPS,
+}
+
+pub enum EventFrame {
+    Frame(Frame),
+    FrameMaxLimit(u32),
 }
 
 #[derive(Debug)]
@@ -61,6 +68,7 @@ impl Default for Options {
 pub struct Session {
     connection: Connection,
     channels: Arc<Mutex<HashMap<u16, SyncSender<AMQPResult<Frame>>>>>,
+    send_sender: SyncSender<EventFrame>,
     channel_max_limit: u16,
     channel_zero: channel::Channel,
 }
@@ -93,19 +101,24 @@ impl Session {
     /// ```
     pub fn new(options: Options) -> AMQPResult<Session> {
         let connection = try!(get_connection(&options));
+
+        let (send_sender, send_receiver) = sync_channel(CHANNEL_BUFFER_SIZE); //writes
+
         let channels = Arc::new(Mutex::new(HashMap::new()));
         let (channel_zero_sender, channel_receiver) = sync_channel(CHANNEL_BUFFER_SIZE); //channel0
-        let channel_zero = channel::Channel::new(0, channel_receiver, connection.clone());
+        let channel_zero = channel::Channel::new(0, channel_receiver, send_sender.clone());
         try!(channels.lock().map_err(|_| AMQPError::SyncError)).insert(0, channel_zero_sender);
         let con1 = connection.clone();
         let channels_clone = channels.clone();
-        thread::spawn(|| Session::reading_loop(con1, channels_clone));
+        thread::spawn(|| Session::reading_loop(con1, channels_clone, send_receiver));
         let mut session = Session {
             connection: connection,
             channels: channels,
+            send_sender: send_sender,
             channel_max_limit: 65535,
             channel_zero: channel_zero,
         };
+
         try!(session.init(options));
         Ok(session)
     }
@@ -215,7 +228,7 @@ impl Session {
     pub fn open_channel(&mut self, channel_id: u16) -> AMQPResult<channel::Channel> {
         debug!("Openning channel: {}", channel_id);
         let (sender, receiver) = sync_channel(CHANNEL_BUFFER_SIZE);
-        let mut channel = channel::Channel::new(channel_id, receiver, self.connection.clone());
+        let mut channel = channel::Channel::new(channel_id, receiver, self.send_sender.clone());
         try!(self.channels.lock().map_err(|_| AMQPError::SyncError)).insert(channel_id, sender);
         try!(channel.open());
         Ok(channel)
@@ -243,12 +256,32 @@ impl Session {
     // Receives and dispatches frames from the connection to the corresponding
     // channels.
     fn reading_loop(mut connection: Connection,
-                    channels: Arc<Mutex<HashMap<u16, SyncSender<AMQPResult<Frame>>>>>)
+                    channels: Arc<Mutex<HashMap<u16, SyncSender<AMQPResult<Frame>>>>>,
+                    send_receiver: Receiver<EventFrame>
+    )
                     -> () {
         debug!("Starting reading loop");
         loop {
+            // thread::sleep(time::Duration::from_secs(1));
+            trace!("Start of the read loop");
+            if let Ok(frame) = send_receiver.try_recv() {
+                match frame {
+                    EventFrame::Frame(frame) => {
+                        trace!("Writing frame: {:?}", frame);
+                        connection.write(frame);
+                    }
+                    EventFrame::FrameMaxLimit(limit) => {
+                        // panic!("set_frame_max_limit issn't working, lol");
+                        connection.frame_max_limit = limit;
+                    }
+
+                    // EventFrame::
+                }
+            }
+
             match connection.read() {
                 Ok(frame) => {
+                    trace!("got frame: {:?}", frame);
                     // TODO: If channel 0 -> send to channel_zero_handler
                     // If channel != 0 and FrameType == METHOD and method class =='connection',
                     // then reply code 503 (command invalid).
@@ -266,7 +299,8 @@ impl Session {
                     dispatch.map_err(|e| error!("{}", e)).ok();
                 }
                 Err(read_err) => {
-                    error!("Error in reading loop: {:?}", read_err);
+                    // error!("Error in reading loop: {:?}", read_err);
+                    /*
                     let chans = channels.lock().unwrap();
                     for chan in chans.values() {
                         // Propagate error to every channel, so they can close
@@ -275,6 +309,7 @@ impl Session {
                         }
                     }
                     break;
+                    */
                 }
             }
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -298,7 +298,7 @@ impl Session {
                     dispatch.map_err(|e| error!("{}", e)).ok();
                 }
                 Err(read_err) => {
-                    error!("Error in reading loop: {:?}", read_err);
+                    trace!("Error in reading loop: {:?}", read_err);
 
                     let mut send_err = false;
 
@@ -316,7 +316,7 @@ impl Session {
                             }
                         }
                         e => {
-                            panic!("Mystery problem! {:?}", e);
+                            error!("Mystery problem! {:?}", e);
                             send_err = true;
                         }
                     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -310,21 +310,14 @@ impl Session {
 
                     let mut send_err = false;
 
-                    match connection.take_error() {
-                        Ok(None) => {},
-                        Ok(Some(err)) => {
-                            let kind = err.kind();
-
-                            match kind {
-                                ErrorKind::WouldBlock => {},
-                                kind => {
-                                    error!("Connection error ({:?}): {:?}", kind, err);
-                                    send_err = true;
-                                }
-                            }
-                        }
-                        e => {
-                            error!("Mystery problem! {:?}", e);
+                    match &read_err {
+                        &AMQPError::IoError(ErrorKind::WouldBlock) => {},
+                        &AMQPError::IoError(kind) => {
+                            error!("Connection IOError ({:?}): {:?}", kind, read_err);
+                            send_err = true;
+                        },
+                        ref e => {
+                            error!("Mystery error! {:?}", e);
                             send_err = true;
                         }
                     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -296,7 +296,10 @@ impl Session {
                     let chan_id = frame.channel;
 
                     if chan_id == 0 {
-                        info!("Dropping mesesage to channel 0: {:?}", frame);
+                        info!(
+                            "Dropping frame to channel 0: {:?}",
+                            String::from_utf8_lossy(frame.payload.inner())
+                        );
                     }
 
                     let target = chans.get(&chan_id);


### PR DESCRIPTION
Closes:
 - https://github.com/Antti/rust-amqp/issues/58
 - https://github.com/Antti/rust-amqp/issues/43

It isn't ideal, the 1s read timeout can slow things down a bit. But: It didn't take much to implement this, and lets me use a recent openssl. I'd be happy to fix it if you have any suggestions on how :)


Basically creates a new syncsender / reader for writes, and the "reading loop" also handles writes now.

This code is definitely POC. If you like it, I would like to clean it up for inclusion.