### PR TITLE
basic_publish: warn when using immediate and mandatory options

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -348,6 +348,14 @@ impl<'a> Basic<'a> for Channel {
                         -> AMQPResult<()>
         where S: Into<String>
     {
+        if mandatory {
+            warn!("basic_publish(mandatory=true) failures are not handled and result in blocked channels!");
+        }
+
+        if immediate {
+            warn!("basic_publish(immediate=true) failures are not handled and result in blocked channels!");
+        }
+
         let publish = &Publish {
             ticket: 0,
             exchange: exchange.into(),


### PR DESCRIPTION
The AMQP library cannot appropriate handle failures in either of these
cases. It is easy for a channel's SyncSender to become full of
NO_ROUTE messages due to mandatory delivery failing. This effectively
causes a deadlock of the client.