### PR TITLE
Log frame payload on dropped frames from channel 0

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -254,6 +254,14 @@ impl Session {
                     // then reply code 503 (command invalid).
                     let chans = channels.lock().unwrap();
                     let chan_id = frame.channel;
+
+                    if chan_id == 0 {
+                        info!(
+                            "Dropping frame to channel 0: {:?}",
+                            String::from_utf8_lossy(frame.payload.inner())
+                        );
+                    }
+
                     let target = chans.get(&chan_id);
                     let dispatch = match target {
                         Some(target_channel) => {


### PR DESCRIPTION
Once the reading loop has begun, messages to
channel 0 are effectively ignored. Sometimes
they contain important information, though, and
not knowing they're being dropped can cause
trouble when debugging other issues.