### PR TITLE
Session: allow specifying custom client properties

### DIFF
--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -2,6 +2,7 @@ extern crate amqp;
 extern crate env_logger;
 
 use amqp::{Session, Options, Table, Basic, protocol, Channel};
+use amqp::TableEntry::LongString;
 use amqp::protocol::basic;
 use std::default::Default;
 
@@ -33,7 +34,13 @@ impl amqp::Consumer for MyConsumer {
 
 fn main() {
     env_logger::init().unwrap();
-    let mut session = Session::new(Options{ vhost: "/".to_string(), .. Default::default()}).ok().expect("Can't create session");
+    let mut props = Table::new();
+    props.insert("example-name".to_owned(), LongString("consumer".to_owned()));
+    let mut session = Session::new(Options{
+        properties: props,
+        vhost: "/".to_string(),
+        .. Default::default()
+    }).ok().expect("Can't create session");
     let mut channel = session.open_channel(1).ok().expect("Error openning channel 1");
     println!("Openned channel: {:?}", channel.id);
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -41,6 +41,7 @@ pub struct Options {
     pub channel_max_limit: u16,
     pub locale: String,
     pub scheme: AMQPScheme,
+    pub properties: Table,
 }
 
 impl Default for Options {
@@ -55,6 +56,7 @@ impl Default for Options {
             channel_max_limit: 65535,
             locale: "en_US".to_string(),
             scheme: AMQPScheme::AMQP,
+            properties: Table::new(),
         }
     }
 }
@@ -144,6 +146,7 @@ impl Session {
         client_properties.insert("version".to_owned(), LongString(VERSION.to_owned()));
         client_properties.insert("information".to_owned(),
                                  LongString("https://github.com/Antti/rust-amqp".to_owned()));
+        client_properties.extend(options.properties);
 
         debug!("Sending connection.start-ok");
         let start_ok = protocol::connection::StartOk {


### PR DESCRIPTION
Client properties can be useful in describing the software being run,
and not just for the actual client library being used.

Extend the client properties with user-supplied properties to allow
library users to specify properties about their software too.