### PR TITLE
Upgrade to the latest openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,8 @@ url = "1.2"
 amq-proto = "0.1.0"
 
 [dependencies.openssl]
-version = "0.7.*"
+version = "0.10"
 optional = true
-features = ["tlsv1_1", "tlsv1_2"]
 
 [dev-dependencies]
 # clippy  = "*"

--- a/src/amqp_error.rs
+++ b/src/amqp_error.rs
@@ -68,8 +68,22 @@ impl From<amq_proto::Error> for AMQPError {
 }
 
 #[cfg(feature = "tls")]
-impl From<openssl::ssl::error::SslError> for AMQPError {
-    fn from(err: openssl::ssl::error::SslError) -> AMQPError {
+impl From<openssl::ssl::Error> for AMQPError {
+    fn from(err: openssl::ssl::Error) -> AMQPError {
+        AMQPError::Protocol(format!("{}", err))
+    }
+}
+
+#[cfg(feature = "tls")]
+impl<T: fmt::Debug> From<openssl::ssl::HandshakeError<T>> for AMQPError {
+    fn from(err: openssl::ssl::HandshakeError<T>) -> AMQPError {
+        AMQPError::Protocol(format!("{}", err))
+    }
+}
+
+#[cfg(feature = "tls")]
+impl From<openssl::error::ErrorStack> for AMQPError {
+    fn from(err: openssl::error::ErrorStack) -> AMQPError {
         AMQPError::Protocol(format!("{}", err))
     }
 }


### PR DESCRIPTION
The version of openssl that was previously used had numerous security issues, and did not support the latest versions of the upstream openssl package.


I wasn't sure what to do about the `impl Clone` on connection, there doesn't appear to be a way to get the current behavior with `SslStream` in the latest version of `openssl`.